### PR TITLE
Fix ArgumentException messages

### DIFF
--- a/tinyply.net/TinyPlyNet/PlyFile.cs
+++ b/tinyply.net/TinyPlyNet/PlyFile.cs
@@ -245,7 +245,7 @@ namespace TinyPlyNet
         {
             if (this.Elements.FindIndex(x => x.Name == elementKey) >= 0)
             {
-                throw new ArgumentException("already exist property key {elementKey}");
+                throw new ArgumentException($"element '{elementKey}' already exists");
             }
 
             var propertyKeyList = propertyKeys.ToList();
@@ -300,7 +300,7 @@ namespace TinyPlyNet
         {
             if (this.Elements.FindIndex(x => x.Name == elementKey) >= 0)
             {
-                throw new ArgumentException("already exist property key {elementKey}");
+                throw new ArgumentException($"element '{elementKey}' already exists");
             }
 
             var cursor = new DataCursor();


### PR DESCRIPTION
## Summary
- mention element names in existing message when adding properties
- mention element names when adding list properties

## Testing
- `dotnet build tinyply.net/tinyplynet.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840067e13708328b1a0de9f7cb6865a