### PR TITLE
fix(culture): specify culture invariant when reading from or writing …

### DIFF
--- a/tinyply.net/TinyPlyNet/Helpers/StreamHelper.cs
+++ b/tinyply.net/TinyPlyNet/Helpers/StreamHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -163,7 +164,7 @@ namespace TinyPlyNet.Helpers
             {
                 w = "NaN";
             }
-            return Convert.ChangeType(w, t);
+            return Convert.ChangeType(w, t, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -215,7 +216,7 @@ namespace TinyPlyNet.Helpers
         /// <param name="value">output value</param>
         public static void WriteData<T>(this TextWriter stream, T value)
         {
-            stream.Write(value);
+            stream.Write(string.Format(CultureInfo.InvariantCulture, "g", value));
             stream.Write(" ");
         }
 

--- a/tinyply.net/TinyPlyNet/Helpers/StreamHelper.cs
+++ b/tinyply.net/TinyPlyNet/Helpers/StreamHelper.cs
@@ -216,7 +216,7 @@ namespace TinyPlyNet.Helpers
         /// <param name="value">output value</param>
         public static void WriteData<T>(this TextWriter stream, T value)
         {
-            stream.Write(string.Format(CultureInfo.InvariantCulture, "g", value));
+            stream.Write(string.Format(CultureInfo.InvariantCulture, "{0:g}", value));
             stream.Write(" ");
         }
 


### PR DESCRIPTION
specify culture invariant when reading from or writing to the stream

Test fail on computer where the decimal separator is a comma instead of a dot

Use InvariantCulture when reading and writing number to the stream